### PR TITLE
Updating hiredis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "http://deepstream.io",
   "optionalDependencies": {
-    "hiredis": "0.1.17"
+    "hiredis": "0.4.1"
   },
   "dependencies": {
     "redis": "0.12.1"


### PR DESCRIPTION
This prevents `hiredis` compilation problems in some environments. See: https://github.com/deepstreamIO/deepstream.io-cache-redis/issues/5
