### PR TITLE
Add example for tls connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ server.set( 'cache', new RedisCacheConnector( {
 
 server.start();
 ```
+
+## Basic Setup with TLS support
+If you need to establish the redis connection via tls, set the `tls` option:
+```yaml
+plugins:
+  cache:
+    name: redis
+    options:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      db: ${REDIS_DB_INDEX} // optional
+      ttl: 86400 // optional time to live in seconds
+      tls: {}
+```
+


### PR DESCRIPTION
As managed redis instances on various cloud providers become more popular it would be nice to see how to configure tls connections as that took me quite a while to figure out. Basically all cloud providers require a tls connection, so I suspect quite a few people are looking for this.